### PR TITLE
Iss8

### DIFF
--- a/R/set_pgfields.R
+++ b/R/set_pgfields.R
@@ -47,7 +47,7 @@ set_pgfields <- function(
     .add_dtype <- function(type = NULL) {
       ou <- dplyr::if_else(type == "factor", "character varying",
                            dplyr::if_else(type == "integer", "smallint",
-                                          dplyr::if_else(type == "numeric", "real",
+                                          dplyr::if_else(type == "numeric", "numeric",
                                                          dplyr::if_else(type == "character", "character varying",
                                                                         "not assigned"))))
       return(ou)

--- a/R/set_pgfields.R
+++ b/R/set_pgfields.R
@@ -42,11 +42,13 @@ set_pgfields <- function(
   if (missing(nchar_df)) nchar_df <- get_nchar(input)
 
   # helper functions
-  .non_default_pgtypes <- function(dat = NULL) {
+  .non_default_pgtypes <- function(dat = NULL, input) {
+
+    if (nrow(input >= 32767)) pg_int <- "integer" else pg_int <- "small_int"
 
     .add_dtype <- function(type = NULL) {
       ou <- dplyr::if_else(type == "factor", "character varying",
-                           dplyr::if_else(type == "integer", "smallint",
+                           dplyr::if_else(type == "integer", pg_int,
                                           dplyr::if_else(type == "numeric", "numeric",
                                                          dplyr::if_else(type == "character", "character varying",
                                                                         "not assigned"))))

--- a/R/update_pgtable.R
+++ b/R/update_pgtable.R
@@ -1,0 +1,127 @@
+#' create_pgfield
+#'
+#' @param conn a object inheriting from \code{DBIDriver} or \code{DBIconection}.
+#' @param table_name a \code{character} string of target table name
+#' @param field_name a \code{character} string of field in specified \code{table}
+#' @param fieldtype a \code{character} string of a Postgres field data type, see \code{?dbDataType}
+#' @param schema a \code{character} string of the schema name, default is \code{public}
+#'
+#' @return
+#' @export
+#'
+#' @examples
+create_pgfield <- function(conn, table_name, field_name, fieldtype, schema) {
+  if (missing(conn)) stop("required connection")
+  if (missing(schema)) schema <- "public"
+  if (missing(table_name)) stop("require table name")
+  if (missing(field_name)) stop("specify column name")
+
+  sql_state <- DBI::sqlInterpolate(conn = conn,
+                                   sql = "ALTER TABLE ?schema.?table ADD COLUMN ?field ?fieldtype",
+                                   schema = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(schema)),
+                                   table = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(table_name)),
+                                   field = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(field_name)),
+                                   fieldtype = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(fieldtype)))
+  qry <- dbSendQuery(conn = conn, statement = sql_state)
+  qry
+  DBI::dbClearResult(qry)
+}
+
+#' update_pgfield
+#'
+#' @param con a object inheriting from \code{DBIDriver} or \code{DBIconection}.
+#' @param table_name a \code{character} of target table name
+#' @param value a \code{vector} to insert into the specified \code{table}
+#' @param field_name a \code{character} string of field in specified \code{table}
+#' @param key a \code{character} string used for the \code{WHERE} SQL clause, recommended to use primary key of table
+#' @param schema a \code{character} of the schema name, default is \code{public}
+#'
+#' @return
+#' @export
+#'
+#' @examples
+update_pgfield <- function(conn, table_name, value, field_name, key, schema, verbose = FALSE, par = TRUE) {
+  if (missing(conn)) stop("required connection")
+  if (missing(schema)) schema <- "public"
+  if (missing(table_name)) stop("require table name")
+  if (missing(field_name)) stop("specify column name")
+
+  if (par) {
+    require(parallel)
+    require(foreach)
+    cl <- parallel::makeCluster(parallel::detectCores()-1)
+    doParallel::registerDoParallel(cl)
+    parallel::clusterEvalQ(cl, {
+      library(DBI)
+      library(RPostgres)
+      conn <- DBI::dbConnect(drv = dbDriver("Postgres"),
+                             host = "localhost",
+                             port = 5432, dbname = "srs_baseline2014_v1",
+                             user = Sys.getenv("db_local_user"),
+                             password = Sys.getenv("db_local_pw")
+      )
+    })
+
+
+    updater <- function(conn, i) {
+      sql_statement <- DBI::sqlInterpolate(
+        conn = conn,
+        sql = paste0("UPDATE ?schema.?table SET ?field = $1 WHERE ?id=",i),
+        schema = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(schema)),
+        table = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(table_name)),
+        field = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(field_name)),
+        id = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(key))
+      )
+      DBI::dbExecute(conn = conn, statement = sql_statement,
+                     params = list(value[i]))
+    }
+
+    foreach(i = seq_along(value), .inorder=FALSE, .noexport = "conn",
+            .packages=c("DBI", "RPostgres")) %dopar% {
+              updater(conn, i)
+            }
+
+  } else if (!par) {
+    for(i in seq_along(value)) {
+      sql_statement <- DBI::sqlInterpolate(
+        conn = conn,
+        sql = paste0("UPDATE ?schema.?table SET ?field = $1 WHERE ?id=",i),
+        schema = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(schema)),
+        table = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(table_name)),
+        field = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(field_name)),
+        id = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(key))
+      )
+      DBI::dbExecute(conn = conn, statement = sql_statement,
+                     params = list(value[i]))
+      if (verbose)
+        message(paste0("[i] = ", i, "/", length(value), " ", round(i/length(value),1)*100, "% complete"))
+    }
+  }
+}
+
+#' drop_pgfield
+#'
+#' @param con a object inheriting from \code{DBIDriver} or \code{DBIconection}.
+#' @param table_name a \code{character} of target table name
+#' @param field_name a \code{character} string of field in specified \code{table}
+#' @param schema a \code{character} of the schema name, default is \code{public}
+#'
+#' @return
+#' @export
+#'
+#' @examples
+drop_pgfield <- function(conn, table_name, field_name, schema) {
+  if (missing(conn)) stop("required connection")
+  if (missing(schema)) schema <- "public"
+  if (missing(table_name)) stop("require table name")
+  if (missing(field_name)) stop("specify column name")
+
+  sql_state <- DBI::sqlInterpolate(conn = conn,
+                                   sql = "ALTER TABLE ?schema.?table DROP COLUMN ?field",
+                                   schema = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(schema)),
+                                   table = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(table_name)),
+                                   field = DBI::dbQuoteIdentifier(conn = conn, DBI::SQL(field_name)))
+  qry <- dbSendQuery(conn = conn, statement = sql_state)
+  qry
+  DBI::dbClearResult(qry)
+}


### PR DESCRIPTION
added logic to assign `integer` vs. `small int` for serial id fields when the input table has greater than 32767 rows (see https://www.postgresql.org/docs/9.5/datatype-numeric.html)